### PR TITLE
Fixes spelling mistake in C# path for sample 1

### DIFF
--- a/ImageSharp/README.md
+++ b/ImageSharp/README.md
@@ -1,7 +1,7 @@
 # ImageSharp Samples
 Various ImageSharp related samples.
 
-1. Resize and add simple effect [c#](./ResizeIamge/) [vb](./ResizeImageVB/)
+1. Resize and add simple effect [c#](./ResizeImage/) [vb](./ResizeImageVB/)
 
    Simple sample of sizing a jpeg and making it greyscale before saving it out as a png.
 


### PR DESCRIPTION
Iamge instead of Image in path.