### PR TITLE
Add RenderQRCode example

### DIFF
--- a/ImageSharp/RenderQRCode/Program.cs
+++ b/ImageSharp/RenderQRCode/Program.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.IO;
-using System.Text;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.PixelFormats;
 
 const int QrCodeSize = 25;
-
 bool[,] pattern = GetQrPattern();
 
 // L8 is a grayscale pixel format storing a single 8-bit (1 byte) channel of luminance per pixel.

--- a/ImageSharp/RenderQRCode/Program.cs
+++ b/ImageSharp/RenderQRCode/Program.cs
@@ -8,8 +8,8 @@ const int QrCodeSize = 25;
 
 bool[,] pattern = GetQrPattern();
 
-// 'L8' is a grayscale pixel format storing a single 8-bit (1 byte) channel of luminance.
-// Do not forget the using keyword so the Image is properly disposed.
+// L8 is a grayscale pixel format storing a single 8-bit (1 byte) channel of luminance per pixel.
+// Do not forget to Dispose Image<L8> in your app! We do it by a using statement in this example:
 using Image<L8> image = RenderQrCodeToImage(pattern, 10);
 
 string fileName = Path.Combine(Directory.GetCurrentDirectory(), "qr.png");

--- a/ImageSharp/RenderQRCode/Program.cs
+++ b/ImageSharp/RenderQRCode/Program.cs
@@ -9,7 +9,7 @@ const int QrCodeSize = 25;
 bool[,] pattern = GetQrPattern();
 
 // L8 is a grayscale pixel format storing a single 8-bit (1 byte) channel of luminance per pixel.
-// Do not forget to Dispose Image<L8> in your app! We do it by a using statement in this example:
+// Make sure to Dispose() the image in your app! We do it by a using statement in this example:
 using Image<L8> image = RenderQrCodeToImage(pattern, 10);
 
 string fileName = Path.Combine(Directory.GetCurrentDirectory(), "qr.png");

--- a/ImageSharp/RenderQRCode/Program.cs
+++ b/ImageSharp/RenderQRCode/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Text;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.PixelFormats;
@@ -85,44 +86,36 @@ static Image<L8> RenderQrCodeToImage(bool[,] pattern, int pixelSize)
     return image;
 }
 
-// Made with http://asciiqr.com/
-const string AsciiQr = @"
-█▀▀▀▀▀█ ▀▀   ▀ ▀▀ █▀▀▀▀▀█
-█ ███ █ █▄ █▀█▄█▀ █ ███ █
-█ ▀▀▀ █ ▀█▀▀▄ █ ▀ █ ▀▀▀ █
-▀▀▀▀▀▀▀ ▀▄▀▄▀ █▄▀ ▀▀▀▀▀▀▀
-██▀█  ▀▄█▄   ▀█  ▀ ▄▀▀▀▄▀
- ▄  ▀▄▀▀▀  ▄▄█▀▄▀█▀▄ ▄▄  
- █ ▄  ▀▀▄▀▄█ ▀▀▄ ▀█▄█ ▀▀█
-▄▀▄ ▄▀▀▀▄▀▀ █  ▄ ▀▄▄█ ▀▀▄
-  ▀   ▀ ▄ █▀▄ ▄██▀▀▀█▀█▀█
-█▀▀▀▀▀█   ▄▀█▀▄▄█ ▀ █ ▀██
-█ ███ █ ▄▀▀▀██ ▄▀▀█▀██▄█▄
-█ ▀▀▀ █ █▀█▀▀▀ ▀▀██ █ █▀ 
-▀▀▀▀▀▀▀ ▀▀  ▀ ▀    ▀▀▀▀▀▀
-";
-
 static bool[,] GetQrPattern()
 {
-    bool[,] pattern = new bool[QrCodeSize, QrCodeSize];
-
-    ReadOnlySpan<char> qrStr = AsciiQr.AsSpan(2); // slice away first \r\n
-    
-    for (int y = 0; y < QrCodeSize; y+=2)
+    const bool o = true;
+    const bool _ = false;
+    return new [,]
     {
-        for (int x = 0; x < QrCodeSize; x++)
-        {
-            char codeChar = qrStr[(y / 2) * (QrCodeSize + 2) + x];
-            pattern[x, y] = codeChar switch { '█' => false, '▀' => false, _ => true };
-            
-            if (y + 1 < QrCodeSize)
-            {
-                pattern[x, y + 1] = codeChar switch { '█' => false, '▄' => false, _ => true };
-            }
-        }
-    }
-
-    return pattern;
+        { _, _, _, _, _, _, _, o, _, _, o, o, o, _, o, _, _, o, _, _, _, _, _, _, _ },
+        { _, o, o, o, o, o, _, o, o, o, o, o, o, o, o, o, o, o, _, o, o, o, o, o, _ },
+        { _, o, _, _, _, o, _, o, _, o, o, _, _, _, o, _, _, o, _, o, _, _, _, o, _ },
+        { _, o, _, _, _, o, _, o, _, _, o, _, o, _, _, _, o, o, _, o, _, _, _, o, _ },
+        { _, o, _, _, _, o, _, o, _, _, _, _, o, o, _, o, _, o, _, o, _, _, _, o, _ },
+        { _, o, o, o, o, o, _, o, o, _, o, o, _, o, _, o, o, o, _, o, o, o, o, o, _ },
+        { _, _, _, _, _, _, _, o, _, o, _, o, _, o, _, o, _, o, _, _, _, _, _, _, _ },
+        { o, o, o, o, o, o, o, o, o, _, o, _, o, o, _, _, o, o, o, o, o, o, o, o, o },
+        { _, _, _, _, o, o, _, o, _, o, o, o, o, _, _, o, o, _, o, o, _, _, _, o, _ },
+        { _, _, o, _, o, o, o, _, _, _, o, o, o, o, _, o, o, o, o, _, o, o, o, _, o },
+        { o, o, o, o, _, o, _, _, _, o, o, o, o, _, _, o, _, _, _, o, o, o, o, o, o },
+        { o, _, o, o, o, _, o, o, o, o, o, _, _, _, o, _, o, _, o, _, o, _, _, o, o },
+        { o, _, o, o, o, o, _, _, o, _, o, _, o, _, _, o, o, _, _, o, _, o, _, _, _ },
+        { o, _, o, _, o, o, o, o, _, o, _, _, o, o, o, _, o, o, _, _, _, o, o, o, _ },
+        { o, _, o, o, o, _, _, _, o, _, _, o, _, o, o, o, o, _, o, o, _, o, _, _, o },
+        { _, o, _, o, _, o, o, o, _, o, o, o, _, o, o, _, o, o, _, _, _, o, o, o, _ },
+        { o, o, _, o, o, o, _, o, o, o, _, _, o, o, o, _, _, _, _, _, _, _, _, _, _ },
+        { o, o, o, o, o, o, o, o, _, o, _, o, _, o, _, _, _, o, o, o, _, o, _, o, _ },
+        { _, _, _, _, _, _, _, o, o, o, o, _, _, _, o, o, _, o, _, o, _, o, _, _, _ },
+        { _, o, o, o, o, o, _, o, o, o, _, o, _, o, _, _, _, o, o, o, _, o, o, _, _ },
+        { _, o, _, _, _, o, _, o, o, _, _, _, _, _, o, o, _, _, _, _, _, _, o, _, o },
+        { _, o, _, _, _, o, _, o, _, o, o, o, _, _, o, _, o, o, _, o, _, _, _, _, _ },
+        { _, o, _, _, _, o, _, o, _, _, _, _, _, _, o, _, _, _, _, o, _, o, _, _, o },
+        { _, o, o, o, o, o, _, o, _, o, _, o, o, o, o, o, o, _, _, o, _, o, _, o, o },
+        { _, _, _, _, _, _, _, o, _, _, o, o, _, o, _, o, o, o, o, _, _, _, _, _, _ },
+    };
 }
-
-

--- a/ImageSharp/RenderQRCode/Program.cs
+++ b/ImageSharp/RenderQRCode/Program.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.IO;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.PixelFormats;
+
+const int QrCodeSize = 25;
+
+bool[,] pattern = GetQrPattern();
+
+// 'L8' is a grayscale pixel format storing a single 8-bit (1 byte) channel of luminance.
+// Do not forget the using keyword so the Image is properly disposed.
+using Image<L8> image = RenderQrCodeToImage(pattern, 10);
+
+string fileName = Path.Combine(Directory.GetCurrentDirectory(), "qr.png");
+
+// Store the result as a grayscale 1 bit per pixel png for maximum compression:
+image.SaveAsPng(fileName, new PngEncoder()
+{
+    BitDepth = PngBitDepth.Bit1,
+    ColorType = PngColorType.Grayscale
+});
+Console.WriteLine($"Saved to: {fileName}");
+
+// ImageSharp 2.0 will break this method: https://github.com/SixLabors/ImageSharp/issues/1739
+// We will update the example after the release. See ImageSharp 2.0 variant in comments.
+static Image<L8> RenderQrCodeToImage(bool[,] pattern, int pixelSize)
+{
+    int imageSize = pixelSize * QrCodeSize;
+    Image<L8> image = new Image<L8>(imageSize, imageSize);
+
+    L8 black = new L8(0);
+    L8 white = new L8(255);
+
+    // Scan the QR pattern row-by-row
+    for (int yQr = 0; yQr < QrCodeSize; yQr++)
+    {
+        // Fill 'pixelSize' number image rows that correspond to the current QR pattern row:
+        for (int y = yQr * pixelSize; y < (yQr + 1) * pixelSize; y++)
+        {
+            // Get a Span<L8> of pixels for the current image row:
+            Span<L8> pixelRow = image.GetPixelRowSpan(y);
+            
+            // Loop through the values for the current QR pattern row:
+            for (int xQr = 0; xQr < QrCodeSize; xQr++)
+            {
+                L8 color = pattern[xQr, yQr] ? white : black;
+                
+                // Fill 'pixelSize' number of image pixels corresponding to the current QR pattern value:
+                for (int x = xQr * pixelSize; x < (xQr + 1) * pixelSize; x++)
+                {
+                    pixelRow[x] = color;
+                }
+            }
+        }
+    }
+    
+    // ImageSharp 2.0 variant:
+    // image.ProcessPixelRows(pixelAccessor =>
+    // {
+    //     // Scan the QR pattern row-by-row
+    //     for (int yQr = 0; yQr < QrCodeSize; yQr++)
+    //     {
+    //         // Fill 'pixelSize' number image rows that correspond to the current QR pattern row:
+    //         for (int y = yQr * pixelSize; y < (yQr + 1) * pixelSize; y++)
+    //         {
+    //             // Get a Span<L8> of pixels for the current image row:
+    //             Span<L8> pixelRow = pixelAccessor.GetRowSpan(y);
+    //
+    //             // Loop through the values for the current QR pattern row:
+    //             for (int xQr = 0; xQr < QrCodeSize; xQr++)
+    //             {
+    //                 L8 color = pattern[xQr, yQr] ? white : black;
+    //
+    //                 // Fill 'pixelSize' number of image pixels corresponding to the current QR pattern value:
+    //                 for (int x = xQr * pixelSize; x < (xQr + 1) * pixelSize; x++)
+    //                 {
+    //                     pixelRow[x] = color;
+    //                 }
+    //             }
+    //         }
+    //     }
+    // });
+
+    return image;
+}
+
+// Made with http://asciiqr.com/
+const string AsciiQr = @"
+█▀▀▀▀▀█ ▀▀   ▀ ▀▀ █▀▀▀▀▀█
+█ ███ █ █▄ █▀█▄█▀ █ ███ █
+█ ▀▀▀ █ ▀█▀▀▄ █ ▀ █ ▀▀▀ █
+▀▀▀▀▀▀▀ ▀▄▀▄▀ █▄▀ ▀▀▀▀▀▀▀
+██▀█  ▀▄█▄   ▀█  ▀ ▄▀▀▀▄▀
+ ▄  ▀▄▀▀▀  ▄▄█▀▄▀█▀▄ ▄▄  
+ █ ▄  ▀▀▄▀▄█ ▀▀▄ ▀█▄█ ▀▀█
+▄▀▄ ▄▀▀▀▄▀▀ █  ▄ ▀▄▄█ ▀▀▄
+  ▀   ▀ ▄ █▀▄ ▄██▀▀▀█▀█▀█
+█▀▀▀▀▀█   ▄▀█▀▄▄█ ▀ █ ▀██
+█ ███ █ ▄▀▀▀██ ▄▀▀█▀██▄█▄
+█ ▀▀▀ █ █▀█▀▀▀ ▀▀██ █ █▀ 
+▀▀▀▀▀▀▀ ▀▀  ▀ ▀    ▀▀▀▀▀▀
+";
+
+static bool[,] GetQrPattern()
+{
+    bool[,] pattern = new bool[QrCodeSize, QrCodeSize];
+
+    ReadOnlySpan<char> qrStr = AsciiQr.AsSpan(2); // slice away first \r\n
+    
+    for (int y = 0; y < QrCodeSize; y+=2)
+    {
+        for (int x = 0; x < QrCodeSize; x++)
+        {
+            char codeChar = qrStr[(y / 2) * (QrCodeSize + 2) + x];
+            pattern[x, y] = codeChar switch { '█' => false, '▀' => false, _ => true };
+            
+            if (y + 1 < QrCodeSize)
+            {
+                pattern[x, y + 1] = codeChar switch { '█' => false, '▄' => false, _ => true };
+            }
+        }
+    }
+
+    return pattern;
+}
+
+

--- a/ImageSharp/RenderQRCode/RenderQRCode.csproj
+++ b/ImageSharp/RenderQRCode/RenderQRCode.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>9.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
+  </ItemGroup>
+</Project>

--- a/Samples.sln
+++ b/Samples.sln
@@ -24,6 +24,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ApplyEffectInsideShape", "I
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CustomImageProcessor", "ImageSharp\CustomImageProcessor\CustomImageProcessor.csproj", "{20B1F090-0C24-4410-8EB1-4B469FD5C404}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RenderQRCode", "ImageSharp\RenderQRCode\RenderQRCode.csproj", "{1E3CB608-7481-4FE1-BB84-B3FFCC1F9A68}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,6 +64,10 @@ Global
 		{20B1F090-0C24-4410-8EB1-4B469FD5C404}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{20B1F090-0C24-4410-8EB1-4B469FD5C404}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{20B1F090-0C24-4410-8EB1-4B469FD5C404}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1E3CB608-7481-4FE1-BB84-B3FFCC1F9A68}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E3CB608-7481-4FE1-BB84-B3FFCC1F9A68}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E3CB608-7481-4FE1-BB84-B3FFCC1F9A68}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E3CB608-7481-4FE1-BB84-B3FFCC1F9A68}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -75,6 +81,7 @@ Global
 		{5BD7AD82-F99B-44D0-8B14-46B00CFF37FF} = {CA7BA24E-2681-4ECF-93FB-404D9505D25F}
 		{7612FC88-232B-408C-9F5B-3B6C9726BCD8} = {CA7BA24E-2681-4ECF-93FB-404D9505D25F}
 		{20B1F090-0C24-4410-8EB1-4B469FD5C404} = {CA7BA24E-2681-4ECF-93FB-404D9505D25F}
+		{1E3CB608-7481-4FE1-BB84-B3FFCC1F9A68} = {CA7BA24E-2681-4ECF-93FB-404D9505D25F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7830D804-EBC6-48A3-9189-BA0B67811CEA}


### PR DESCRIPTION
This example:
- Demonstrates how to process an image row-by row with a real-life use-case
- Demonstrates the usage of a non-default L8 pixel type, and saving the result to a GrayScale 1bpp PNG
- May help users of the popular [QRCoder](https://github.com/codebude/QRCoder) library to mitigate the obsolation of System.Drawing in their own applications. (`byte[,] pattern` should be compatible with `AbstractQRCode.QrCodeData.ModuleMatrix`)
- May help QRCoder to port the library to ImageSharp -- see https://github.com/codebude/QRCoder/issues/315

/cc @JimBobSquarePants @safern